### PR TITLE
🚸 Verification de l'entre users champs paramscreen

### DIFF
--- a/pages/ParamScreen.tsx
+++ b/pages/ParamScreen.tsx
@@ -28,9 +28,9 @@ export default function ParamScreen() {
     icon: "",
   });
 
-  const [urlerror, setUrlError] = useState(false);
+  const [urlError, setUrlError] = useState(false);
 
-  const [usererror, setUserError] = useState(false);
+  const [userError, setUserError] = useState(false);
 
   useEffect(() => {
     // Init de la page
@@ -43,7 +43,7 @@ export default function ParamScreen() {
 
     setValueForm({ ...valueForm, urlApi: newValue });
 
-    const urlRegex = /^(https?:\/\/)?[a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+\+.~#?&//=]*)$/;
+    const urlRegex = /^(https?:\/\/)?[a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&/]*)$/;
     // Vérifier si l'URL est valide selon la regex
     const matches = urlRegex.test(newValue);
     // Si une correspondance est trouvée, mettre à jour le valeur de urlApi
@@ -78,7 +78,7 @@ export default function ParamScreen() {
   const handleOnClickSubmit = () => {
     // stockage dans le AsyncStorage
    
-    if (usererror || urlerror) {
+    if (userError || urlError) {
       displaySnackBar('Erreur de saisie dans le formulaire !', "alert-circle");
       return 
     }
@@ -118,7 +118,7 @@ export default function ParamScreen() {
             placeholder="URL API"
             onChangeText={handleOnChangeURL}
             value={valueForm.urlApi.toLowerCase()}
-            error={urlerror}
+            error={urlError}
             autoCapitalize="none"
           />
         </View>
@@ -131,7 +131,7 @@ export default function ParamScreen() {
            ou nom enqueteur"
             onChangeText={handleOnChangeUser}
             value={valueForm.user}
-            error={usererror}
+            error={userError}
           />
         </View>
         <View style={style.buttonArea}>

--- a/pages/ParamScreen.tsx
+++ b/pages/ParamScreen.tsx
@@ -28,6 +28,10 @@ export default function ParamScreen() {
     icon: "",
   });
 
+  const [urlerror, setUrlError] = useState(false);
+
+  const [usererror, setUserError] = useState(false);
+
   useEffect(() => {
     // Init de la page
 
@@ -36,18 +40,48 @@ export default function ParamScreen() {
   }, []);
 
   const handleOnChangeURL = (newValue: string) => {
+
     setValueForm({ ...valueForm, urlApi: newValue });
-    //TODO: rajouter vérification sur URL
+
+    const urlRegex = /^(https?:\/\/)?[a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+\+.~#?&//=]*)$/;
+    // Vérifier si l'URL est valide selon la regex
+    const matches = urlRegex.test(newValue);
+    // Si une correspondance est trouvée, mettre à jour le valeur de urlApi
+    if (matches) {
+      setValueForm({ ...valueForm, urlApi: newValue });
+      setUrlError(false);
+    } else {
+      // Sinon, afficher un message d'erreur
+      console.log("L'URL n'est pas valide");
+      setUrlError(true);
+    }
   };
 
   const handleOnChangeUser = (newValue: string) => {
+    
     setValueForm({ ...valueForm, user: newValue });
-    //TODO: rajouter vérification sur user
+
+    const urlRegex = /^(?:[A-Z]{3}|[A-Z][a-z]+(?: [A-Z][a-z]+)*)$/;
+    // Vérifier si l'URL est valide selon la regex
+    const matches = urlRegex.test(newValue);
+    // Si une correspondance est trouvée, mettre à jour le valeur de urlApi
+    if (matches) {
+      setValueForm({ ...valueForm, user: newValue.toLowerCase()});
+      setUserError(false);
+    } else {
+      // Sinon, afficher un message d'erreur
+      console.log("L'URL n'est pas valide");
+      setUserError(true);
+    }
   };
 
   const handleOnClickSubmit = () => {
     // stockage dans le AsyncStorage
-    //TODO: appliquer une vérification de la cohérence, via des regex par exemple
+   
+    if (usererror || urlerror) {
+      displaySnackBar('Erreur de saisie dans le formulaire !', "alert-circle");
+      return 
+    }
     storageService.saveData(
       valueForm,
       "configuration",
@@ -55,6 +89,7 @@ export default function ParamScreen() {
       failureSave
     );
     setConfig(valueForm);
+
   };
 
   const succesSave = () => {
@@ -69,6 +104,7 @@ export default function ParamScreen() {
 
   const displaySnackBar = (label: string, icon: string) => {
     setSnackBar({ label: label, icon: icon, visible: true });
+
   };
 
   return (
@@ -81,7 +117,9 @@ export default function ParamScreen() {
             label="Endpoint API"
             placeholder="URL API"
             onChangeText={handleOnChangeURL}
-            value={valueForm.urlApi}
+            value={valueForm.urlApi.toLowerCase()}
+            error={urlerror}
+            autoCapitalize="none"
           />
         </View>
         <View>
@@ -93,6 +131,7 @@ export default function ParamScreen() {
            ou nom enqueteur"
             onChangeText={handleOnChangeUser}
             value={valueForm.user}
+            error={usererror}
           />
         </View>
         <View style={style.buttonArea}>


### PR DESCRIPTION
Vérification de l'entrée des utilisateurs dans les deux champs de la page paramscreen avec des regex et mise en minuscule du champ url (la valeur est mise en minuscule). Ajout de méthodes de vérification des champs url et de user.
Valeurs forcées sur la lowercase pour éviter des erreurs de endpoint.