### PR TITLE
💄 Les noms de gare longs ne dépassent plus

### DIFF
--- a/components/DetailCourse.tsx
+++ b/components/DetailCourse.tsx
@@ -94,6 +94,6 @@ const style = StyleSheet.create({
   },
   detailTime: {
     flexDirection: "row",
-    width: 200,
+    // width: 200,
   },
 });


### PR DESCRIPTION
Je pense que le problème des noms de trains trop long venait simplement de ce width à 200.